### PR TITLE
allow multi-word searches

### DIFF
--- a/lib/exzeitable/database.ex
+++ b/lib/exzeitable/database.ex
@@ -68,8 +68,13 @@ defmodule Exzeitable.Database do
 
   @doc "We only want letters to avoid SQL injection attacks"
   @spec prefix_search(String.t()) :: String.t()
-  def prefix_search(term) do
-    String.replace(term, ~r/\W|_/u, "") <> ":*"
+  def prefix_search(terms) do
+    terms
+    |> String.split()
+    |> Enum.map(fn term ->
+      String.replace(term, ~r/\W|_/u, "") <> ":*"
+    end)
+    |> Enum.join(" & ")
   end
 
   @doc """

--- a/test/exzeitable/database_test.exs
+++ b/test/exzeitable/database_test.exs
@@ -108,5 +108,12 @@ defmodule Exzeitable.DatabaseTest do
     assert generated == expected
   end
 
+  test "prefix_string/1 handles multiple search terms separated by space" do
+    assert Database.prefix_search("bananas apples") == "bananas:* & apples:*"
+    assert Database.prefix_search("baNANas ApPlEs") == "baNANas:* & ApPlEs:*"
+    assert Database.prefix_search("ba@NAN%as @appLeS$") == "baNANas:* & appLeS:*"
+    assert Database.prefix_search("   ba_@nan%as    a_@pple$s1   ") == "bananas:* & apples1:*"
+  end
+
   def names(users), do: users |> Enum.map(fn u -> Map.get(u, :name) end)
 end


### PR DESCRIPTION
This updates `Exzeitable.Database.prefix_search/1` to allow for multi-word searches by separating the words in a search string and processing them individually.

Closes #246 