### PR TITLE
Add formatter option for fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The following field options are available (with their defaults):
 - `hidden: false` Hide the column by default (user can click show button to reveal)
 - `search: true` Whether to include the column in search results. See the important note below.
 - `order: true` Do not allow the column to be sorted (hide the sort button)
+- `formatter: {Exzeitable.HTML.Format, :format}` Specifies a formatter function that will be applied to the column content when formatting. The formatter can be specified as either `{Mod, fun}` or `{Mod, fun, args}`. If `{Mod, fun, args}` is used then the content to be formatted is prepended to the list of `args` before calling `fun`. The default formatter calls `to_string/1`.
 - `virtual: false` This is shorthand for [function: true, search: false, order: false] and will override those settings. Intended for creating fields that are not database backed.
 
 **IMPORTANT NOTE**: Search uses [ts_vector](https://www.postgresql.org/docs/10/datatype-textsearch.html), which is performed by Postgres inside the database on string fields. This means that you cannot search fields that are _not_ string type (i.e. integer, datetime, associations, virtual fields). Make sure to set `search: false` or `virtual: true` on such fields.

--- a/cypress/integration/acceptance_test.js
+++ b/cypress/integration/acceptance_test.js
@@ -83,6 +83,12 @@ describe('Acceptance Test', function () {
     cy.contains('Nex').should('not.exist')
   })
 
+  it('Can use custom formatter', function () {
+    cy.visit('http://localhost:5000/users/formatted')
+    cy.contains('<<< Bob >>>')
+    cy.contains('!!!boB!!!')
+  })
+
   it('Can use custom text', function () {
     cy.visit('http://localhost:5000/beitrage')
     cy.contains('Beiträge auflisten')

--- a/lib/exzeitable/html/format.ex
+++ b/lib/exzeitable/html/format.ex
@@ -21,6 +21,7 @@ defmodule Exzeitable.HTML.Format do
     else
       Map.get(entry, key, nil)
     end
+    |> format_field(fields[key].formatter)
   end
 
   # coveralls-ignore-stop
@@ -45,5 +46,22 @@ defmodule Exzeitable.HTML.Format do
     |> Map.delete(:assigns)
     |> Map.merge(assigns)
     |> then(&Map.put(socket, :assigns, &1))
+  end
+
+  # The default formatter
+  def format_field(value) do
+    to_string(value)
+  end
+
+  # Called for configured formatters which can be in the format
+  # {mod, fun}
+  # {mod, fun, args} in which case the value is prepended to `args`
+
+  defp format_field(value, {mod, fun}) do
+    apply(mod, fun, [value])
+  end
+
+  defp format_field(value, {mod, fun, args}) do
+    apply(mod, fun, [value | args])
   end
 end

--- a/lib/exzeitable/parameters.ex
+++ b/lib/exzeitable/parameters.ex
@@ -4,6 +4,7 @@ defmodule Exzeitable.Parameters do
 
   Validates that parameters are valid.
   """
+  alias Exzeitable.HTML.Format
   alias Exzeitable.Parameters.{ParameterError, Validation}
 
   @parameters %{
@@ -20,7 +21,8 @@ defmodule Exzeitable.Parameters do
     pagination: %{default: [:top, :bottom]},
     parent: %{default: nil},
     assigns: %{default: %{}},
-    text: %{default: Exzeitable.Text.Default}
+    text: %{default: Exzeitable.Text.Default},
+    formatter: %{default: {Format, :fornat_field}}
   }
 
   @default_fields [
@@ -28,7 +30,8 @@ defmodule Exzeitable.Parameters do
     function: false,
     hidden: false,
     search: true,
-    order: true
+    order: true,
+    formatter: {Format, :format_field}
   ]
 
   @virtual_fields [

--- a/lib/exzeitable/parameters.ex
+++ b/lib/exzeitable/parameters.ex
@@ -22,7 +22,7 @@ defmodule Exzeitable.Parameters do
     parent: %{default: nil},
     assigns: %{default: %{}},
     text: %{default: Exzeitable.Text.Default},
-    formatter: %{default: {Format, :fornat_field}}
+    formatter: %{default: {Format, :format_field}}
   }
 
   @default_fields [

--- a/lib/test_web/controllers/user_controller.ex
+++ b/lib/test_web/controllers/user_controller.ex
@@ -58,4 +58,7 @@ defmodule TestWeb.UserController do
     |> put_flash(:info, "User deleted successfully.")
     |> redirect(to: Routes.user_path(conn, :index))
   end
+
+  # For testing formatter configuration
+  def formatted_index(conn, _params), do: render(conn, "formatted_index.html")
 end

--- a/lib/test_web/live_tables/user_formatted_table.ex
+++ b/lib/test_web/live_tables/user_formatted_table.ex
@@ -1,0 +1,33 @@
+defmodule TestWeb.UserFormattedTable do
+  @moduledoc "User table"
+  alias TestWeb.Router.Helpers, as: Routes
+  alias TestWeb.User
+
+  use Exzeitable,
+    repo: TestWeb.Repo,
+    routes: Routes,
+    path: :user_path,
+    fields: [
+      name: [formatter: {TestWeb.UserFormattedTable, :format}],
+      age: [label: "Years old", search: false],
+      name_backwards: [formatter: {TestWeb.UserFormattedTable, :format, ["!!!"]}, virtual: true]
+    ],
+    query: from(u in User),
+    per_page: 5
+
+  def render(assigns), do: ~H"<%= build_table(assigns) %>"
+
+  def name_backwards(_socket, entry) do
+    entry
+    |> Map.get(:name)
+    |> String.reverse()
+  end
+
+  def format(value) do
+    "<<< " <> to_string(value) <> " >>>"
+  end
+
+  def format(value, string) do
+    string <> to_string(value) <> string
+  end
+end

--- a/lib/test_web/router.ex
+++ b/lib/test_web/router.ex
@@ -20,6 +20,7 @@ defmodule TestWeb.Router do
 
     get("/", PostController, :index)
     get("/beitrage", BeitrageController, :index)
+    get("/users/formatted", UserController, :formatted_index)
     resources("/users", UserController)
     get("/posts/no_action_buttons", PostController, :no_action_buttons)
     get("/posts/disable_hide", PostController, :disable_hide)

--- a/lib/test_web/templates/user/formatted_index.html.heex
+++ b/lib/test_web/templates/user/formatted_index.html.heex
@@ -1,0 +1,2 @@
+<h1>Listing Formatted User</h1>
+<%= TestWeb.UserFormattedTable.live_table(@conn, action_buttons: []) %>

--- a/test/exzeitable/parameters_test.exs
+++ b/test/exzeitable/parameters_test.exs
@@ -12,7 +12,14 @@ defmodule Exzeitable.ParametersTest do
     ]
 
     after_merge = [
-      first: [function: false, hidden: false, search: true, order: true, label: "something"]
+      first: [
+        function: false,
+        hidden: false,
+        search: true,
+        order: true,
+        formatter: {Exzeitable.HTML.Format, :format_field},
+        label: "something"
+      ]
     ]
 
     assert Parameters.set_fields(opts) == after_merge
@@ -28,6 +35,7 @@ defmodule Exzeitable.ParametersTest do
     after_merge = [
       first: [
         hidden: false,
+        formatter: {Exzeitable.HTML.Format, :format_field},
         label: "something",
         virtual: true,
         function: true,


### PR DESCRIPTION
This commit adds an option :formatter to
the :fields definition for a live table.

The :formatter is called for each value
inserted in the live table.

The formatter can be specified as either:

* {Mod, fun} or
* {Mod, fun, args} in which case the value to
  be formatted is prepended to args before
  calling the formatter.

Formatters cannot be function captures (ie
&Mod.fun/1) because this results in serialization
errors.

The default function ultimately calls the
expected `to_string/1` and therefore is compatible
with the existing implementation.